### PR TITLE
Adding the ability to configure a dead-letter worker

### DIFF
--- a/lib/radioactive_bunnies/deadletter_worker.rb
+++ b/lib/radioactive_bunnies/deadletter_worker.rb
@@ -1,0 +1,46 @@
+module RadioactiveBunnies
+  module DeadletterWorker
+    module ClassMethods
+      def register_with_deadletter_worker(worker_class)
+        deadletter_producers << worker_class.name
+      end
+
+      def deadletter_producers
+        @dl_producers ||= []
+      end
+
+      def deadletter_init(worker_opts)
+        return unless !!worker_opts[:deadletter_workers]
+        worker_list = [worker_opts[:deadletter_workers]].flatten
+        exchanges = worker_list.inject([]) do |deadletter_exchange, worker|
+          worker_klass = RadioactiveBunnies::Ext::Util.constantize!(worker)
+          worker_klass.register_with_deadletter_worker(self)
+          deadletter_exchange << worker_klass.queue_opts[:exchange][:name]
+        end
+        validate_deadletter_exchanges!(exchanges)
+      end
+
+      def validate_deadletter_exchanges!(exchanges)
+        raise DeadletterError.multiple_exchanges(self, exchanges) unless 1 == exchanges.uniq.count
+        raise DeadletterError.nil_exchange(self) if exchanges.include? nil
+        self.deadletter_exchange = exchanges.first
+      end
+
+    end
+
+    class << self
+      def deadletter_queue_config(q_opts)
+        return {} unless !!q_opts[:deadletter_exchange]
+        {arguments: {'x-dead-letter-exchange' => q_opts[:deadletter_exchange]}}
+      end
+    end
+  end
+  class DeadletterError < StandardError
+    def self.multiple_exchanges(klass, exchanges)
+      new("Multiple deadletter exchanges in [#{klass.name}] - exchanges are <#{exchanges}>")
+    end
+    def self.nil_exchange(klass)
+      new("Found nil for deadletter exchange name in [#{klass.name}]")
+    end
+  end
+end

--- a/lib/radioactive_bunnies/worker.rb
+++ b/lib/radioactive_bunnies/worker.rb
@@ -1,17 +1,16 @@
 require 'atomic'
 require 'radioactive_bunnies/context'
-
+require 'radioactive_bunnies/deadletter_worker'
 module RadioactiveBunnies::Worker
-
   def ack!
     true
   end
 
-  def work
-  end
+  def work; end
 
   def self.included(base)
     base.extend ClassMethods
+    base.extend RadioactiveBunnies::DeadletterWorker::ClassMethods
     RadioactiveBunnies::Context.add_worker(base)
   end
 
@@ -73,6 +72,10 @@ module RadioactiveBunnies::Worker
       @queue_name
     end
 
+    def deadletter_exchange=(exchange)
+      @queue_opts[:deadletter_exchange] = exchange
+    end
+
     def jobs_stats
       Hash[ @jobs_stats.map{ |k,v| [k, v.value] } ].merge({ :since => @working_since.to_i })
     end
@@ -80,11 +83,12 @@ module RadioactiveBunnies::Worker
     private
 
     def startup_init
-      @jobs_stats = { :failed => Atomic.new(0), :passed => Atomic.new(0) }
       @working_since = Time.now
+      @jobs_stats = { :failed => Atomic.new(0), :passed => Atomic.new(0) }
       @queue_opts[:exchange] ||= @context.default_exchange
       @logger = @context.logger
       set_thread_pool
+      deadletter_init(@queue_opts)
     end
 
     def set_thread_pool

--- a/spec/radioactive_bunnies/deadletter_worker_spec.rb
+++ b/spec/radioactive_bunnies/deadletter_worker_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+require 'radioactive_bunnies'
+require 'support/workers/timeout_worker'
+JOB_TIMEOUT = 1
+class DeadletterDefaultWorker
+  include RadioactiveBunnies::Worker
+  from_queue 'deadletter.default',
+    prefetch: 20, durable: false, timeout_job_after: 5, threads: 1, append_env: true,
+    exchange: {type: :fanout, name: 'deadletter.exchange'}
+  def work(metadata, msg)
+    true
+  end
+end
+
+class DeadletterDefaultWorkerTwo
+  include RadioactiveBunnies::Worker
+  from_queue 'deadletter.default.two',
+    prefetch: 20, durable: false, timeout_job_after: 5, threads: 1, append_env: true,
+    exchange: {type: :fanout, name: nil}
+
+  def work(metadata, msg)
+    true
+  end
+end
+
+class DeadletterProducer
+  include RadioactiveBunnies::Worker
+  from_queue 'deadletter.producer',
+    prefetch: 20, timeout_job_after: JOB_TIMEOUT, threads: 2,
+    deadletter_workers: ['DeadletterDefaultWorker']
+  def work(metadata, msg)
+    sleep (JOB_TIMEOUT + 5)
+  end
+end
+
+class DeadletterProducerNonArray
+  include RadioactiveBunnies::Worker
+  from_queue 'deadletter.producer.nonarray',
+    prefetch: 20, timeout_job_after: 1, threads: 2,
+    deadletter_workers: 'DeadletterDefaultWorker'
+  def work(metadata, msg)
+    false
+  end
+end
+
+class DeadletterProducerBroken
+  include RadioactiveBunnies::Worker
+  from_queue 'deadletter.producer.nonarray',
+    prefetch: 20, timeout_job_after: 1, threads: 2,
+    deadletter_workers: %w(DeadletterDefaultWorker DeadletterDefaultWorkerTwo)
+  def work(metadata, msg)
+    false
+  end
+end
+
+describe RadioactiveBunnies::DeadletterWorker do
+
+  before(:all) do
+    @conn = MarchHare.connect
+    @ch = @conn.create_channel
+    @ctx = RadioactiveBunnies::Context.new
+    @ctx.log_with(Logger.new(STDOUT))
+    @ctx.run DeadletterProducer, DeadletterDefaultWorker, DeadletterProducerNonArray
+    ['deadletter.producer', 'deadletter.producer.nonarray'].each do |r_key|
+      @ch.default_exchange.publish("hello world", routing_key: r_key)
+    end
+    sleep 2
+  end
+
+  after(:all) do
+    @conn.close
+    @ctx.stop
+  end
+  context 'when a worker has at least one deadletter class' do
+
+    it 'registers with the specified deadletter worker based on a single string class name' do
+      expect(DeadletterDefaultWorker.deadletter_producers).to include(DeadletterProducer.name)
+    end
+    it 'notifies the deadletter worker when a single deadletter work is identified' do
+      expect(DeadletterDefaultWorker.deadletter_producers).to include(DeadletterProducerNonArray.name)
+    end
+
+    context 'with two deadletter workers requesting different deadletter exchange names' do
+      it 'a worker raises an error on start' do
+        expect{DeadletterProducerBroken.start(@ctx)}.
+          to raise_error RadioactiveBunnies::DeadletterError
+      end
+    end
+    context 'with a deadletter worker that has a nil exchange name' do
+      it 'a worker raises an error on start' do
+        DeadletterProducerBroken.queue_opts[:deadletter_workers] = 'DeadletterDefaultWorkerTwo'
+        expect{DeadletterProducerBroken.start(@ctx)}.
+          to raise_error RadioactiveBunnies::DeadletterError
+      end
+    end
+  end
+
+  describe '.deadletter_queue_config(q_opts)' do
+    it 'returns a hash containing an arguments key with the deadletter exchange config' do
+      expect(described_class.deadletter_queue_config(DeadletterProducer.queue_opts)).
+        to include(arguments: {'x-dead-letter-exchange' => DeadletterDefaultWorker.queue_opts[:exchange][:name]})
+    end
+  end
+
+  context 'when a worker with deadletter enabled timesout' do
+    it 'sends the deadletter to the correct deadletter worker' do
+      expect(DeadletterDefaultWorker.jobs_stats[:passed]).to eql 2
+    end
+  end
+end

--- a/spec/support/workers/timeout_worker.rb
+++ b/spec/support/workers/timeout_worker.rb
@@ -1,7 +1,11 @@
 require 'radioactive_bunnies'
 class TimeoutWorker
   include RadioactiveBunnies::Worker
-  from_queue 'timeout.worker', timeout_job_after: 1, prefetch: 1, threads: 1
+  from_queue 'timeout.worker',
+    timeout_job_after: 1,
+    prefetch: 1,
+    threads: 1
+
   def work(metadata, msg)
     while(true) do
     end


### PR DESCRIPTION
In a worker queue opts set the dead-letter_workers to the string class name a worker configured to handle dead-letters for your worker. During startup the worker requesting dead-letters will register with the dead-letter work and will properly grab the dead-letter workers exchange name for the configuration of the dead-letter exchange in the queue arguments
